### PR TITLE
feat: add video downsampling step

### DIFF
--- a/ai_graph/step/video/video_downsampling.py
+++ b/ai_graph/step/video/video_downsampling.py
@@ -1,0 +1,256 @@
+"""
+Video Downsampling Step.
+
+This module provides a pipeline step for downsampling a video to a specified
+frames-per-second (FPS) rate.
+"""
+
+import logging
+import os
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import cv2
+import torch
+
+from ..base import BasePipelineStep
+
+logger = logging.getLogger(__name__)
+
+
+class VideoDownsamplingStep(BasePipelineStep):
+    """
+    Pipeline step to downsample a video to a target FPS, resolution, and/or format.
+
+    This step takes a video file path, processes it according to specified
+    output parameters (FPS, resolution, format), and saves the output video
+    next to the original file with a '_downsampled' suffix, along with
+    resolution and FPS information if provided. It uses FFmpeg for the
+    conversion and can leverage GPU acceleration (NVIDIA's NVENC) if a
+    compatible GPU and CUDA are detected.
+
+    Examples:
+       # Example 1: Downsample to 15 FPS
+       downsample_fps_step = VideoDownsamplingStep(output_fps=15)
+
+       # Example 2: Downsample to 720p resolution
+       downsample_res_step = VideoDownsamplingStep(output_resolution="1280x720")
+
+       # Example 3: Convert to WebM format
+       convert_format_step = VideoDownsamplingStep(output_format="webm")
+
+       # Example 4: Downsample to 10 FPS, 480p resolution, and MP4 format
+       full_downsample_step = VideoDownsamplingStep(
+           output_fps=10,
+           output_resolution="640x480",
+           output_format="mp4"
+       )
+    """
+
+    def __init__(
+        self,
+        output_fps: Optional[int] = 5,
+        output_resolution: Optional[str] = None,
+        output_format: Optional[str] = None,
+        name: Optional[str] = None,
+    ):
+        """
+        Initializes the VideoDownsamplingStep.
+
+        Args:
+            output_fps (int): The target frames-per-second for the output video.
+            output_resolution (str, optional): The target resolution for the output video (e.g., "1280x720").
+            output_format (str, optional): The target format for the output video (e.g., "mp4", "webm").
+            name (str, optional): The name of the pipeline step. Defaults to "VideoDownsampling".
+
+        Example:
+            >>> step = VideoDownsamplingStep(output_fps=15, output_resolution="1280x720", output_format="mp4")
+        """
+        super().__init__(name or "VideoDownsampling")
+        self.output_fps = output_fps
+        self.output_resolution = output_resolution
+        self.output_format = output_format
+
+    def _process_step(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Downsamples the video specified in the input data.
+
+        This method reads the 'video_path' from the input data, checks if the
+        video needs downsampling, performs the downsampling using FFmpeg, and
+        updates the 'video_path' in the data to point to the new downsampled file.
+
+        Args:
+            data (Dict[str, Any]): A dictionary containing the 'video_path' to the
+                video file to be downsampled.
+
+        Returns:
+            Dict[str, Any]: The updated data dictionary with 'video_path' pointing
+                to the processed video file if downsampling/conversion was performed.
+                It also includes 'output_fps', 'output_resolution', 'output_format',
+                and the original 'video_fps'.
+
+        Raises:
+            FileNotFoundError: If the video_path is not found or is invalid.
+            RuntimeError: If FFmpeg fails to open or process the video.
+
+        Example:
+            >>> from ai_graph.step.video.video_downsampling import VideoDownsamplingStep
+            >>> step = VideoDownsamplingStep(output_fps=10, output_resolution="640x480", output_format="mp4")
+            >>> data = {"video_path": "/path/to/your/video.mp4"}
+            >>> # For a runnable example, you would need to mock os.path.isfile, cv2.VideoCapture, and subprocess.run
+            >>> # processed_data = step._process_step(data)
+            >>> # print(processed_data["video_path"])
+            # Expected output (if mocks were in place):
+            # /path/to/your/video_downsampled_640x480_10fps.mp4
+        """
+        video_path = data.get("video_path")
+        if not video_path or not os.path.isfile(video_path):
+            raise FileNotFoundError(f"Invalid video path: {video_path}")
+
+        # Get original fps
+        cap = cv2.VideoCapture(video_path)
+        if not cap.isOpened():
+            raise RuntimeError(f"Failed to open video: {video_path}")
+        original_fps = cap.get(cv2.CAP_PROP_FPS)
+        cap.release()
+
+        logger.info(f"Original FPS: {original_fps:.2f}")
+        logger.info(f"Target FPS: {self.output_fps}")
+
+        if self.output_fps is not None and original_fps == self.output_fps:
+            logger.info("Original FPS and Target FPS are the same. Skipping downsampling.")
+            data["output_fps"] = self.output_fps
+            data["video_fps"] = original_fps
+            data["output_resolution"] = self.output_resolution
+            data["output_format"] = self.output_format
+            return data
+
+        video_p = Path(video_path)
+
+        # Construct output filename based on provided parameters
+        output_stem = video_p.stem + "_downsampled"
+
+        output_suffix = f".{self.output_format}" if self.output_format else video_p.suffix
+        output_path = str(video_p.with_name(f"{output_stem}{output_suffix}"))
+
+        start_time = time.time()
+        try:
+            self._downsample_video(video_path, output_path, self.output_fps, self.output_resolution, self.output_format)
+            data["video_path"] = output_path
+        except Exception as e:
+            logger.error(f"Error downsampling video {video_path}: {e}")
+            raise
+
+        elapsed = time.time() - start_time
+        logger.info(f"Downsampling took {elapsed:.2f} seconds")
+
+        data["output_fps"] = self.output_fps
+        data["video_fps"] = original_fps
+        data["output_resolution"] = self.output_resolution
+        data["output_format"] = self.output_format
+        return data
+
+    def _downsample_video(
+        self,
+        input_path: str,
+        output_path: str,
+        output_fps: Optional[int],
+        output_resolution: Optional[str],
+        output_format: Optional[str],
+    ) -> None:
+        """
+        Performs the video downsampling using FFmpeg.
+
+        This method constructs and executes an FFmpeg command to change the video's
+        FPS and/or resolution. It automatically selects hardware acceleration (h264_nvenc) if a
+        CUDA-enabled GPU is available, otherwise, it falls back to CPU-based
+        encoding (libx264).
+
+        Args:
+            input_path (str): The path to the input video file.
+            output_path (str): The path where the downsampled video will be saved.
+            output_fps (Optional[int]): The target frames-per-second for the output video.
+            output_resolution (Optional[str]): The target resolution for the output video (e.g., "1280x720").
+            output_format (Optional[str]): The target format for the output video (e.g., "mp4", "webm").
+
+        Raises:
+            RuntimeError: If the FFmpeg command fails to execute.
+
+        Example:
+            >>> # This example assumes ffmpeg is installed and accessible in the system's PATH.
+            >>> # It also assumes a dummy video file exists at '/tmp/input_video.mp4'.
+            >>> # Mocking subprocess.run and torch.cuda.is_available would be necessary for a real test.
+            >>> from pathlib import Path
+            >>> from unittest.mock import patch, MagicMock
+            >>> from ai_graph.step.video.video_downsampling import VideoDownsamplingStep
+            >>>
+            >>> # Mock subprocess.run to prevent actual ffmpeg execution during example run
+            >>> with patch('subprocess.run', return_value=MagicMock(returncode=0, stdout="success", stderr="")):
+            >>>     # Mock torch.cuda.is_available to simulate no GPU
+            >>>     with patch('torch.cuda.is_available', return_value=False):
+            >>>         step = VideoDownsamplingStep()
+            >>>         # Instance is not used for _downsample_video directly, but for context
+            >>>         input_path = "/tmp/input_video.mp4"
+            >>>         output_path = "/tmp/output_video_downsampled.mp4"
+            >>>         # Call the static method directly for demonstration
+            >>>         VideoDownsamplingStep._downsample_video(step, input_path, output_path, 15, "640x480", "mp4")
+            >>>         # In a real scenario, you would check if output_video_downsampled.mp4 was created.
+        """
+        try:
+            use_gpu = torch.cuda.is_available()
+
+            filters = []
+            if output_fps is not None:
+                filters.append(f"fps={output_fps}")
+            if output_resolution is not None:
+                filters.append(f"scale={output_resolution}")
+
+            vf_param = f'-vf "{",".join(filters)}"' if filters else ""
+
+            # Determine video codec based on format
+            video_codec_gpu = "h264_nvenc"
+            video_codec_cpu = "libx264"
+            if output_format == "webm":
+                video_codec_gpu = "libvpx-vp9"  # NVENC doesn't support VP9 directly, so fallback to CPU for webm
+                video_codec_cpu = "libvpx-vp9"
+            elif output_format == "mp4":
+                video_codec_gpu = "h264_nvenc"
+                video_codec_cpu = "libx264"
+            # Add more format-codec mappings as needed
+
+            # Ensure output_path uses POSIX-style separators for ffmpeg
+            ffmpeg_output_path = Path(output_path).as_posix()
+
+            if use_gpu:
+                logger.info("GPU detected - using hardware acceleration for ffmpeg")
+                cmd = (
+                    f'ffmpeg -hwaccel cuda -i "{input_path}" {vf_param} '
+                    f"-c:v {video_codec_gpu} -preset fast -c:a copy "
+                    f'-max_muxing_queue_size 9999 -y "{ffmpeg_output_path}"'
+                )
+            else:
+                logger.info("No GPU detected - using CPU for ffmpeg")
+                cmd = (
+                    f'ffmpeg -i "{input_path}" {vf_param} '
+                    f"-c:v {video_codec_cpu} -preset fast -c:a copy "
+                    f'-max_muxing_queue_size 9999 -y "{ffmpeg_output_path}"'
+                )
+
+            # Execute the ffmpeg command
+            result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+
+            # Check for errors
+            if result.returncode != 0:
+                logger.error(f"FFmpeg error: {result.stderr}")
+                raise RuntimeError(f"FFmpeg failed with exit code {result.returncode}")
+            else:
+                logger.info(f"Successfully downsampled video to {output_path}")
+
+        except subprocess.CalledProcessError as e:
+            logger.error(f"FFmpeg command failed: {e.stderr}")
+            raise RuntimeError(f"FFmpeg failed: {e.stderr}") from e
+        except Exception as e:
+            logger.error(f"An error occurred: {str(e)}")
+            raise

--- a/ai_graph/step/video/video_downsampling.py
+++ b/ai_graph/step/video/video_downsampling.py
@@ -42,7 +42,8 @@ def check_ffmpeg_availability() -> Tuple[str, str]:
 
 def install_ffmpeg() -> Tuple[str, str]:
     """
-    Runs the 'ffdl install' command to install FFmpeg and FFprobe, automatically answering 'y' to the confirmation prompt.
+    Runs the 'ffdl install' command to install FFmpeg and FFprobe,
+    automatically answering 'y' to the confirmation prompt.
 
     Returns:
         tuple: Paths to the installed ffmpeg and ffprobe executables.
@@ -144,7 +145,8 @@ class VideoDownsamplingStep(BasePipelineStep):
             RuntimeError: If FFprobe fails to retrieve the FPS.
         """
         try:
-            cmd = f'"{self.ffprobe_path}" -v error -select_streams v:0 -show_entries stream=r_frame_rate -of json "{video_path}"'
+            cmd = f'"{self.ffprobe_path}" -v error -select_streams v:0 -show_entries "'
+            'stream=r_frame_rate -of json "{video_path}"'
             result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
             if result.returncode != 0:
                 raise RuntimeError(f"FFprobe failed to retrieve FPS: {result.stderr}")

--- a/ai_graph/step/video/video_downsampling.py
+++ b/ai_graph/step/video/video_downsampling.py
@@ -11,7 +11,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 import ffmpeg_downloader as ffdl
 
@@ -20,7 +20,7 @@ from ai_graph.step.base import BasePipelineStep
 logger = logging.getLogger(__name__)
 
 
-def check_ffmpeg_availability():
+def check_ffmpeg_availability() -> Tuple[str, str]:
     """
     Checks if FFmpeg and FFprobe are available on the system. If not, attempts to install them using ffmpeg-downloader.
 
@@ -40,7 +40,7 @@ def check_ffmpeg_availability():
         return install_ffmpeg()
 
 
-def install_ffmpeg():
+def install_ffmpeg() -> Tuple[str, str]:
     """
     Runs the 'ffdl install' command to install FFmpeg and FFprobe, automatically answering 'y' to the confirmation prompt.
 

--- a/examples/video_downsampling_example.ipynb
+++ b/examples/video_downsampling_example.ipynb
@@ -1,0 +1,326 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Video Downsampling with VideoDownsamplingStep\n",
+    "\n",
+    "This Jupyter Notebook demonstrates how to use the `VideoDownsamplingStep` class from the `ai_graph` Python package to downsample a video to a specified frames-per-second (FPS), resolution, and format. The code uses FFmpeg for video processing and supports GPU acceleration if available. We'll also download a sample video using `wget` to test the downsampling process.\n",
+    "\n",
+    "## Prerequisites\n",
+    "- **FFmpeg**: Ensure FFmpeg is installed and accessible in your system's PATH.\n",
+    "- **Python Libraries**: Install required libraries (`ai_graph`, `opencv-python`, `torch`).\n",
+    "- **wget**: For downloading the sample video.\n",
+    "\n",
+    "Let's walk through the process step-by-step."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 1: Install Required Libraries\n",
+    "\n",
+    "First, let's install the necessary Python libraries. Run the following cell to install `ai_graph`, `opencv-python`, and `torch` if they are not already installed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install ai_graph opencv-python torch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 2: Download a Sample Video\n",
+    "\n",
+    "We'll use `wget` to download a sample video from a public source. For this example, we'll download a short, royalty-free video from [Pexels](https://www.pexels.com). The video will be saved as `sample_video.mp4`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "--2025-08-18 17:11:46--  https://www.pexels.com/video/857251/download/\n",
+      "Resolving www.pexels.com (www.pexels.com)... 10.10.34.36\n",
+      "Connecting to www.pexels.com (www.pexels.com)|10.10.34.36|:443... failed: Unknown error.\n",
+      "Retrying.\n",
+      "\n",
+      "--2025-08-18 17:12:09--  (try: 2)  https://www.pexels.com/video/857251/download/\n",
+      "Connecting to www.pexels.com (www.pexels.com)|10.10.34.36|:443... failed: Unknown error.\n",
+      "Retrying.\n",
+      "\n",
+      "--2025-08-18 17:12:32--  (try: 3)  https://www.pexels.com/video/857251/download/\n",
+      "Connecting to www.pexels.com (www.pexels.com)|10.10.34.36|:443... failed: Unknown error.\n",
+      "Retrying.\n",
+      "\n",
+      "--2025-08-18 17:12:56--  (try: 4)  https://www.pexels.com/video/857251/download/\n",
+      "Connecting to www.pexels.com (www.pexels.com)|10.10.34.36|:443... failed: Unknown error.\n",
+      "Retrying.\n",
+      "\n",
+      "--2025-08-18 17:13:21--  (try: 5)  https://www.pexels.com/video/857251/download/\n",
+      "Connecting to www.pexels.com (www.pexels.com)|10.10.34.36|:443... failed: Unknown error.\n",
+      "Retrying.\n",
+      "\n",
+      "--2025-08-18 17:13:47--  (try: 6)  https://www.pexels.com/video/857251/download/\n",
+      "Connecting to www.pexels.com (www.pexels.com)|10.10.34.36|:443... failed: Unknown error.\n",
+      "Retrying.\n",
+      "\n",
+      "--2025-08-18 17:14:14--  (try: 7)  https://www.pexels.com/video/857251/download/\n",
+      "Connecting to www.pexels.com (www.pexels.com)|10.10.34.36|:443... failed: Unknown error.\n",
+      "Retrying.\n",
+      "\n",
+      "--2025-08-18 17:14:42--  (try: 8)  https://www.pexels.com/video/857251/download/\n",
+      "Connecting to www.pexels.com (www.pexels.com)|10.10.34.36|:443... failed: Unknown error.\n",
+      "Retrying.\n",
+      "\n",
+      "--2025-08-18 17:15:11--  (try: 9)  https://www.pexels.com/video/857251/download/\n",
+      "Connecting to www.pexels.com (www.pexels.com)|10.10.34.36|:443... failed: Unknown error.\n",
+      "Retrying.\n",
+      "\n",
+      "--2025-08-18 17:15:41--  (try:10)  https://www.pexels.com/video/857251/download/\n",
+      "Connecting to www.pexels.com (www.pexels.com)|10.10.34.36|:443... failed: Unknown error.\n",
+      "Retrying.\n",
+      "\n",
+      "--2025-08-18 17:16:12--  (try:11)  https://www.pexels.com/video/857251/download/\n",
+      "Connecting to www.pexels.com (www.pexels.com)|10.10.34.36|:443... failed: Unknown error.\n",
+      "Retrying.\n",
+      "\n",
+      "--2025-08-18 17:16:43--  (try:12)  https://www.pexels.com/video/857251/download/\n",
+      "Connecting to www.pexels.com (www.pexels.com)|10.10.34.36|:443... failed: Unknown error.\n",
+      "Retrying.\n",
+      "\n",
+      "--2025-08-18 17:17:14--  (try:13)  https://www.pexels.com/video/857251/download/\n",
+      "Connecting to www.pexels.com (www.pexels.com)|10.10.34.36|:443... failed: Unknown error.\n",
+      "Retrying.\n",
+      "\n",
+      "--2025-08-18 17:17:45--  (try:14)  https://www.pexels.com/video/857251/download/\n",
+      "Connecting to www.pexels.com (www.pexels.com)|10.10.34.36|:443... failed: Unknown error.\n",
+      "Retrying.\n",
+      "\n",
+      "--2025-08-18 17:18:16--  (try:15)  https://www.pexels.com/video/857251/download/\n",
+      "Connecting to www.pexels.com (www.pexels.com)|10.10.34.36|:443... failed: Unknown error.\n",
+      "Retrying.\n",
+      "\n",
+      "--2025-08-18 17:18:47--  (try:16)  https://www.pexels.com/video/857251/download/\n",
+      "Connecting to www.pexels.com (www.pexels.com)|10.10.34.36|:443... failed: Unknown error.\n",
+      "Retrying.\n",
+      "\n",
+      "--2025-08-18 17:19:19--  (try:17)  https://www.pexels.com/video/857251/download/\n",
+      "Connecting to www.pexels.com (www.pexels.com)|10.10.34.36|:443... failed: Unknown error.\n",
+      "Retrying.\n",
+      "\n",
+      "--2025-08-18 17:19:50--  (try:18)  https://www.pexels.com/video/857251/download/\n",
+      "Connecting to www.pexels.com (www.pexels.com)|10.10.34.36|:443... failed: Unknown error.\n",
+      "Retrying.\n",
+      "\n",
+      "--2025-08-18 17:20:21--  (try:19)  https://www.pexels.com/video/857251/download/\n",
+      "Connecting to www.pexels.com (www.pexels.com)|10.10.34.36|:443... failed: Unknown error.\n",
+      "Retrying.\n",
+      "\n",
+      "--2025-08-18 17:20:52--  (try:20)  https://www.pexels.com/video/857251/download/\n",
+      "Connecting to www.pexels.com (www.pexels.com)|10.10.34.36|:443... failed: Unknown error.\n",
+      "Giving up.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "\n",
+    "# Download a sample video using wget\n",
+    "video_url = \"https://sample-videos.com/video321/mp4/720/big_buck_bunny_720p_50mb.mp4\"\n",
+    "video_file_name = \"sample_video.mp4\"\n",
+    "!wget -O {video_file_name} {video_url}\n",
+    "\n",
+    "# Verify the video was downloaded\n",
+    "if os.path.isfile(video_file_name):\n",
+    "    print(f\"Sample video downloaded successfully: {video_file_name}\")\n",
+    "else:\n",
+    "    print(\"Failed to download the sample video.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3: Import the VideoDownsamplingStep\n",
+    "\n",
+    "The `VideoDownsamplingStep` class is part of the `ai_graph` package. It handles video downsampling by adjusting FPS, resolution, and/or format using FFmpeg. Below, we import the necessary classes from `ai_graph`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ai_graph.pipeline.base import Pipeline\n",
+    "from ai_graph.step.video.video_downsampling import VideoDownsamplingStep\n",
+    "import logging\n",
+    "import os\n",
+    "import cv2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 4: Set Up Logging\n",
+    "\n",
+    "To see detailed logs during the downsampling process, let's configure the logging module."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 5: Run the Video Downsampling Pipeline\n",
+    "\n",
+    "Now, let's create a pipeline, add the `VideoDownsamplingStep`, and process the downloaded sample video. We'll downsample it to 1 FPS, 640x360 resolution, and MP4 format."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define the path to the input video\n",
+    "video_path = os.path.abspath(video_file_name)\n",
+    "\n",
+    "# Define output parameters\n",
+    "output_fps = 1\n",
+    "output_resolution = \"640x360\"\n",
+    "output_format = \"mp4\"\n",
+    "\n",
+    "# Create a pipeline\n",
+    "pipeline = Pipeline(name=\"VideoDownsamplingPipeline\")\n",
+    "\n",
+    "# Add the VideoDownsamplingStep to the pipeline\n",
+    "pipeline.add_step(\n",
+    "    VideoDownsamplingStep(\n",
+    "        output_fps=output_fps,\n",
+    "        output_resolution=output_resolution,\n",
+    "        output_format=output_format,\n",
+    "        name=\"DownsampleVideo\"\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "# Prepare the input data for the pipeline\n",
+    "input_data = {\"video_path\": video_path}\n",
+    "\n",
+    "print(f\"Starting video downsampling for: {video_path}\")\n",
+    "print(f\"Target FPS: {output_fps}, Resolution: {output_resolution}, Format: {output_format}\")\n",
+    "\n",
+    "# Process the video through the pipeline\n",
+    "result = pipeline.process(input_data)\n",
+    "\n",
+    "print(\"\\nVideo downsampling pipeline completed.\")\n",
+    "print(\"Result:\")\n",
+    "print(result)\n",
+    "\n",
+    "# Check the downsampled video path\n",
+    "if \"video_path\" in result:\n",
+    "    print(f\"Downsampled video saved to: {result['video_path']}\")\n",
+    "else:\n",
+    "    print(\"Downsampled video path not found in result.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 6: Verify the Output\n",
+    "\n",
+    "After running the pipeline, the downsampled video should be saved in the same directory as the input video with a `_downsampled` suffix (e.g., `sample_video_downsampled.mp4`). You can verify the output file exists and check its properties using `cv2`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Verify the output video\n",
+    "if \"video_path\" in result and os.path.isfile(result[\"video_path\"]):\n",
+    "    cap = cv2.VideoCapture(result[\"video_path\"])\n",
+    "    if cap.isOpened():\n",
+    "        fps = cap.get(cv2.CAP_PROP_FPS)\n",
+    "        width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))\n",
+    "        height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))\n",
+    "        print(f\"Output video FPS: {fps}\")\n",
+    "        print(f\"Output video resolution: {width}x{height}\")\n",
+    "        cap.release()\n",
+    "    else:\n",
+    "        print(\"Failed to open the downsampled video.\")\n",
+    "else:\n",
+    "    print(\"Output video file not found.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Explanation of the Code\n",
+    "\n",
+    "- **VideoDownsamplingStep**: This class, part of the `ai_graph.step.video` module, inherits from `BasePipelineStep` and handles video downsampling. It takes parameters like `output_fps`, `output_resolution`, and `output_format` to specify the target video properties.\n",
+    "- **_process_step**: This method checks the input video, retrieves its original FPS using OpenCV, and decides whether downsampling is needed. It constructs the output filename and calls `_downsample_video`.\n",
+    "- **_downsample_video**: This method builds and executes an FFmpeg command to perform the downsampling. It supports GPU acceleration (using `h264_nvenc`) if a CUDA-enabled GPU is detected via `torch.cuda.is_available()`. Otherwise, it uses CPU-based encoding (`libx264` for MP4, `libvpx-vp9` for WebM).\n",
+    "- **Pipeline**: The `Pipeline` class from `ai_graph.pipeline.base` manages the execution of steps. In this case, it only contains the `VideoDownsamplingStep`.\n",
+    "\n",
+    "## Notes\n",
+    "- Ensure FFmpeg is installed and accessible in your system's PATH.\n",
+    "- If you have a CUDA-enabled GPU, the code will attempt to use hardware acceleration, which can significantly speed up processing.\n",
+    "- The output video is saved with a `_downsampled` suffix in the same directory as the input video.\n",
+    "- If the original FPS matches the target FPS, the downsampling step is skipped to avoid unnecessary processing."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/mypy.ini
+++ b/mypy.ini
@@ -30,3 +30,6 @@ ignore_missing_imports = True
 
 [mypy-pytest.*]
 ignore_missing_imports = True
+
+[mypy-ffmpeg_downloader.*]
+ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ requires-python = ">=3.9"
 dependencies = [
     "opencv-python-headless",
     "tqdm>=4.64.0",
+    "ffmpeg_downloader"
 ]
 
 [project.urls]

--- a/tests/step/test_video/test_video_downsampling.py
+++ b/tests/step/test_video/test_video_downsampling.py
@@ -1,0 +1,232 @@
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import cv2
+import numpy as np
+import pytest
+
+# Import the class to be tested
+from ai_graph.step.video.video_downsampling import VideoDownsamplingStep
+
+
+# Mock torch.cuda.is_available globally for consistent testing environment
+# We'll control this in specific tests if needed
+@pytest.fixture(autouse=True)
+def mock_cuda_availability():
+    with patch("torch.cuda.is_available", return_value=False) as mock_is_available:
+        yield mock_is_available
+
+
+@pytest.fixture
+def create_dummy_video():
+    """Fixture to create a dummy video file for testing."""
+    temp_dir = tempfile.mkdtemp()
+    video_path = os.path.join(temp_dir, "dummy_video.mp4")
+
+    # Create a simple dummy video using OpenCV
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")  # Codec for .mp4
+    fps = 10
+    width, height = 640, 480
+    out = cv2.VideoWriter(video_path, fourcc, fps, (width, height))
+
+    for _ in range(fps * 2):  # 2 seconds of video
+        frame = np.random.randint(0, 255, (height, width, 3), dtype=np.uint8)
+        out.write(frame)
+    out.release()
+
+    yield video_path
+
+    # Clean up the dummy video file and directory
+    os.remove(video_path)
+    os.rmdir(temp_dir)
+
+
+class TestVideoDownsamplingStep:
+    class TestDunderInit:
+        def test_init_default_parameters(self):
+            step = VideoDownsamplingStep()
+            assert step.name == "VideoDownsampling"
+            assert step.output_fps == 5
+            assert step.output_resolution is None
+            assert step.output_format is None
+
+        def test_init_custom_parameters(self):
+            step = VideoDownsamplingStep(
+                output_fps=10, output_resolution="1920x1080", output_format="webm", name="CustomDownsample"
+            )
+            assert step.name == "CustomDownsample"
+            assert step.output_fps == 10
+            assert step.output_resolution == "1920x1080"
+            assert step.output_format == "webm"
+
+    class TestUnderlineProcessStep:
+        @pytest.fixture(autouse=True)
+        def setup_mocks(self):
+            # Mock os.path.isfile
+            with patch("os.path.isfile", return_value=True) as mock_isfile:
+                self.mock_isfile = mock_isfile
+                # Mock cv2.VideoCapture
+                with patch("cv2.VideoCapture") as mock_video_capture:
+                    self.mock_cap = MagicMock()
+                    self.mock_cap.isOpened.return_value = True
+                    self.mock_cap.get.side_effect = lambda prop: {
+                        cv2.CAP_PROP_FPS: 30.0,
+                        cv2.CAP_PROP_FRAME_WIDTH: 1920,
+                        cv2.CAP_PROP_FRAME_HEIGHT: 1080,
+                    }.get(prop, 0)
+                    mock_video_capture.return_value = self.mock_cap
+                    # Mock subprocess.run
+                    with patch("subprocess.run") as mock_subprocess_run:
+                        self.mock_subprocess_run = mock_subprocess_run
+                        self.mock_subprocess_run.return_value = MagicMock(returncode=0, stdout="success", stderr="")
+                        yield
+
+        def test_process_step_raises_file_not_found_error_if_video_path_invalid(self):
+            self.mock_isfile.return_value = False
+            step = VideoDownsamplingStep()
+            data = {"video_path": "/path/to/nonexistent.mp4"}
+            with pytest.raises(FileNotFoundError, match="Invalid video path"):
+                step._process_step(data)
+
+        def test_process_step_raises_runtime_error_if_video_capture_fails_to_open(self):
+            self.mock_cap.isOpened.return_value = False
+            step = VideoDownsamplingStep()
+            data = {"video_path": "/path/to/video.mp4"}
+            with pytest.raises(RuntimeError, match="Failed to open video"):
+                step._process_step(data)
+
+        def test_process_step_skips_downsampling_if_output_fps_matches_original(self):
+            self.mock_cap.get.side_effect = lambda prop: {cv2.CAP_PROP_FPS: 30.0}.get(prop, 0)
+            step = VideoDownsamplingStep(output_fps=30)
+            data = {"video_path": "/path/to/video.mp4"}
+
+            result = step._process_step(data)
+
+            self.mock_subprocess_run.assert_not_called()  # Assert ffmpeg was not called
+            assert result["output_fps"] == 30
+            assert result["video_fps"] == 30.0
+            assert "video_path" in result  # Original video path should still be there
+            assert result["video_path"] == "/path/to/video.mp4"  # Should not be changed
+
+        @pytest.mark.parametrize(
+            "output_fps, output_resolution, output_format, expected_vf_param, "
+            "expected_codec_cpu, expected_codec_gpu, expected_suffix",
+            [
+                (15, None, None, '-vf "fps=15"', "libx264", "h264_nvenc", ".mp4"),
+                (None, "1280x720", None, '-vf "scale=1280x720"', "libx264", "h264_nvenc", ".mp4"),
+                (None, None, "webm", "", "libvpx-vp9", "libvpx-vp9", ".webm"),
+                (10, "640x480", "mp4", '-vf "fps=10,scale=640x480"', "libx264", "h264_nvenc", ".mp4"),
+                (5, "1920x1080", "webm", '-vf "fps=5,scale=1920x1080"', "libvpx-vp9", "libvpx-vp9", ".webm"),
+            ],
+        )
+        def test_process_step_happy_path_generates_correct_ffmpeg_command_and_updates_data(
+            self,
+            output_fps,
+            output_resolution,
+            output_format,
+            expected_vf_param,
+            expected_codec_cpu,
+            expected_codec_gpu,
+            expected_suffix,
+            mock_cuda_availability,
+        ):
+            # Arrange
+            original_video_path = "/path/to/original_video.mp4"
+            original_fps = 30.0
+            self.mock_cap.get.side_effect = lambda prop: {cv2.CAP_PROP_FPS: original_fps}.get(prop, 0)
+
+            step = VideoDownsamplingStep(
+                output_fps=output_fps, output_resolution=output_resolution, output_format=output_format
+            )
+            data = {"video_path": original_video_path}
+
+            # Mock Path.with_name to control the output filename
+            mock_path_obj = MagicMock()
+            mock_path_obj.stem = "original_video"
+            mock_path_obj.suffix = ".mp4"
+            expected_output_stem = mock_path_obj.stem + "_downsampled"
+            expected_output_filename = expected_output_stem + expected_suffix
+            expected_output_path = f"/path/to/{expected_output_filename}"  # Use forward slashes
+            mock_path_obj.with_name.return_value = Path(expected_output_path)
+
+            with patch("pathlib.Path", return_value=mock_path_obj):
+                # Act
+                result = step._process_step(data)
+
+                # Assert
+                self.mock_subprocess_run.assert_called_once()
+                called_cmd = self.mock_subprocess_run.call_args[0][0]
+
+                # Check common parts of the command
+                assert f'ffmpeg -i "{original_video_path}"' in called_cmd
+                if expected_vf_param:  # Only include -vf if filters are present
+                    assert expected_vf_param in called_cmd
+                else:
+                    assert "-vf" not in called_cmd  # Ensure -vf is not present when no filters
+
+                # Check codec based on GPU availability
+                if mock_cuda_availability.return_value:
+                    assert f"-c:v {expected_codec_gpu}" in called_cmd
+                else:
+                    assert f"-c:v {expected_codec_cpu}" in called_cmd
+
+                assert "-c:a copy -max_muxing_queue_size 9999 -y" in called_cmd
+                assert f'"{expected_output_path}"' in called_cmd  # Use POSIX-style path
+
+                # Verify data dictionary updates
+                assert result["output_fps"] == output_fps
+                assert result["output_resolution"] == output_resolution
+                assert result["output_format"] == output_format
+                assert result["video_fps"] == original_fps
+                assert result["video_path"] == str(mock_path_obj.with_name.return_value)
+
+        def test_process_step_raises_runtime_error_if_ffmpeg_fails(self):
+            self.mock_subprocess_run.return_value = MagicMock(returncode=1, stdout="", stderr="FFmpeg error message")
+            step = VideoDownsamplingStep(output_fps=15)
+            data = {"video_path": "/path/to/video.mp4"}
+
+            with pytest.raises(RuntimeError, match="FFmpeg failed with exit code 1"):
+                step._process_step(data)
+
+        def test_process_step_uses_gpu_acceleration_when_available(self, mock_cuda_availability):
+            mock_cuda_availability.return_value = True  # Simulate GPU available
+            step = VideoDownsamplingStep(output_fps=15)
+            data = {"video_path": "/path/to/video.mp4"}
+
+            # Mock Path.with_name to control the output filename
+            mock_path_obj = MagicMock()
+            mock_path_obj.stem = "video"
+            mock_path_obj.suffix = ".mp4"
+            mock_path_obj.with_name.return_value = Path("/path/to/video_15fps.mp4")
+            with patch("pathlib.Path", return_value=mock_path_obj):
+                step._process_step(data)
+
+            called_cmd = self.mock_subprocess_run.call_args[0][0]
+            assert "-hwaccel cuda" in called_cmd
+            assert "-c:v h264_nvenc" in called_cmd  # Default GPU codec for mp4
+
+        def test_process_step_uses_cpu_when_gpu_not_available(self, mock_cuda_availability):
+            mock_cuda_availability.return_value = False  # Simulate GPU not available (default)
+            step = VideoDownsamplingStep(output_fps=15)
+            data = {"video_path": "/path/to/video.mp4"}
+
+            # Mock Path.with_name to control the output filename
+            mock_path_obj = MagicMock()
+            mock_path_obj.stem = "video"
+            mock_path_obj.suffix = ".mp4"
+            mock_path_obj.with_name.return_value = Path("/path/to/video_15fps.mp4")
+            with patch("pathlib.Path", return_value=mock_path_obj):
+                step._process_step(data)
+
+            called_cmd = self.mock_subprocess_run.call_args[0][0]
+            assert "-hwaccel cuda" not in called_cmd  # Should not use GPU accel
+            assert "-c:v libx264" in called_cmd  # Default CPU codec for mp4
+
+        def test_process_step_handles_missing_video_path_in_data(self):
+            step = VideoDownsamplingStep()
+            data = {}  # Missing video_path
+
+            with pytest.raises(FileNotFoundError, match="Invalid video path"):
+                step._process_step(data)

--- a/tests/step/test_video/test_video_downsampling.py
+++ b/tests/step/test_video/test_video_downsampling.py
@@ -1,232 +1,241 @@
+import json
 import os
-import tempfile
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import cv2
-import numpy as np
 import pytest
 
-# Import the class to be tested
-from ai_graph.step.video.video_downsampling import VideoDownsamplingStep
-
-
-# Mock torch.cuda.is_available globally for consistent testing environment
-# We'll control this in specific tests if needed
-@pytest.fixture(autouse=True)
-def mock_cuda_availability():
-    with patch("torch.cuda.is_available", return_value=False) as mock_is_available:
-        yield mock_is_available
+from ai_graph.step.video.video_downsampling import (
+    VideoDownsamplingStep,
+    check_ffmpeg_availability,
+    install_ffmpeg,
+)
 
 
 @pytest.fixture
-def create_dummy_video():
-    """Fixture to create a dummy video file for testing."""
-    temp_dir = tempfile.mkdtemp()
-    video_path = os.path.join(temp_dir, "dummy_video.mp4")
-
-    # Create a simple dummy video using OpenCV
-    fourcc = cv2.VideoWriter_fourcc(*"mp4v")  # Codec for .mp4
-    fps = 10
-    width, height = 640, 480
-    out = cv2.VideoWriter(video_path, fourcc, fps, (width, height))
-
-    for _ in range(fps * 2):  # 2 seconds of video
-        frame = np.random.randint(0, 255, (height, width, 3), dtype=np.uint8)
-        out.write(frame)
-    out.release()
-
-    yield video_path
-
-    # Clean up the dummy video file and directory
-    os.remove(video_path)
-    os.rmdir(temp_dir)
+def mock_subprocess_run():
+    """Fixture to mock subprocess.run for FFmpeg and FFprobe commands."""
+    with patch("subprocess.run") as mock_run:
+        yield mock_run
 
 
-class TestVideoDownsamplingStep:
-    class TestDunderInit:
-        def test_init_default_parameters(self):
-            step = VideoDownsamplingStep()
-            assert step.name == "VideoDownsampling"
-            assert step.output_fps == 5
-            assert step.output_resolution is None
-            assert step.output_format is None
+@pytest.fixture
+def mock_path_isfile():
+    """Fixture to mock os.path.isfile."""
+    with patch("os.path.isfile") as mock_isfile:
+        yield mock_isfile
 
-        def test_init_custom_parameters(self):
-            step = VideoDownsamplingStep(
-                output_fps=10, output_resolution="1920x1080", output_format="webm", name="CustomDownsample"
-            )
-            assert step.name == "CustomDownsample"
-            assert step.output_fps == 10
-            assert step.output_resolution == "1920x1080"
-            assert step.output_format == "webm"
 
-    class TestUnderlineProcessStep:
-        @pytest.fixture(autouse=True)
-        def setup_mocks(self):
-            # Mock os.path.isfile
-            with patch("os.path.isfile", return_value=True) as mock_isfile:
-                self.mock_isfile = mock_isfile
-                # Mock cv2.VideoCapture
-                with patch("cv2.VideoCapture") as mock_video_capture:
-                    self.mock_cap = MagicMock()
-                    self.mock_cap.isOpened.return_value = True
-                    self.mock_cap.get.side_effect = lambda prop: {
-                        cv2.CAP_PROP_FPS: 30.0,
-                        cv2.CAP_PROP_FRAME_WIDTH: 1920,
-                        cv2.CAP_PROP_FRAME_HEIGHT: 1080,
-                    }.get(prop, 0)
-                    mock_video_capture.return_value = self.mock_cap
-                    # Mock subprocess.run
-                    with patch("subprocess.run") as mock_subprocess_run:
-                        self.mock_subprocess_run = mock_subprocess_run
-                        self.mock_subprocess_run.return_value = MagicMock(returncode=0, stdout="success", stderr="")
-                        yield
+@pytest.fixture
+def video_downsampling_step():
+    """Fixture to create a VideoDownsamplingStep instance."""
+    return VideoDownsamplingStep(
+        output_fps=10, output_resolution="640x480", output_format="mp4"
+    )
 
-        def test_process_step_raises_file_not_found_error_if_video_path_invalid(self):
-            self.mock_isfile.return_value = False
-            step = VideoDownsamplingStep()
-            data = {"video_path": "/path/to/nonexistent.mp4"}
-            with pytest.raises(FileNotFoundError, match="Invalid video path"):
-                step._process_step(data)
 
-        def test_process_step_raises_runtime_error_if_video_capture_fails_to_open(self):
-            self.mock_cap.isOpened.return_value = False
-            step = VideoDownsamplingStep()
-            data = {"video_path": "/path/to/video.mp4"}
-            with pytest.raises(RuntimeError, match="Failed to open video"):
-                step._process_step(data)
+def test_check_ffmpeg_availability_success(mock_subprocess_run):
+    """Test check_ffmpeg_availability when FFmpeg and FFprobe are available."""
+    mock_subprocess_run.side_effect = [
+        MagicMock(returncode=0),  # ffmpeg -version
+        MagicMock(returncode=0),  # ffprobe -version
+    ]
+    ffmpeg_path, ffprobe_path = check_ffmpeg_availability()
+    assert ffmpeg_path == "ffmpeg"
+    assert ffprobe_path == "ffprobe"
+    assert mock_subprocess_run.call_count == 2
 
-        def test_process_step_skips_downsampling_if_output_fps_matches_original(self):
-            self.mock_cap.get.side_effect = lambda prop: {cv2.CAP_PROP_FPS: 30.0}.get(prop, 0)
-            step = VideoDownsamplingStep(output_fps=30)
-            data = {"video_path": "/path/to/video.mp4"}
 
-            result = step._process_step(data)
+def test_check_ffmpeg_availability_not_found(mock_subprocess_run):
+    """Test check_ffmpeg_availability when FFmpeg/FFprobe are not found."""
+    mock_subprocess_run.side_effect = FileNotFoundError
+    with patch(
+        "ai_graph.step.video.video_downsampling.install_ffmpeg",
+        return_value=("/path/to/ffmpeg", "/path/to/ffprobe"),
+    ) as mock_install:
+        ffmpeg_path, ffprobe_path = check_ffmpeg_availability()
+        assert ffmpeg_path == "/path/to/ffmpeg"
+        assert ffprobe_path == "/path/to/ffprobe"
+        mock_install.assert_called_once()
 
-            self.mock_subprocess_run.assert_not_called()  # Assert ffmpeg was not called
-            assert result["output_fps"] == 30
-            assert result["video_fps"] == 30.0
-            assert "video_path" in result  # Original video path should still be there
-            assert result["video_path"] == "/path/to/video.mp4"  # Should not be changed
 
-        @pytest.mark.parametrize(
-            "output_fps, output_resolution, output_format, expected_vf_param, "
-            "expected_codec_cpu, expected_codec_gpu, expected_suffix",
-            [
-                (15, None, None, '-vf "fps=15"', "libx264", "h264_nvenc", ".mp4"),
-                (None, "1280x720", None, '-vf "scale=1280x720"', "libx264", "h264_nvenc", ".mp4"),
-                (None, None, "webm", "", "libvpx-vp9", "libvpx-vp9", ".webm"),
-                (10, "640x480", "mp4", '-vf "fps=10,scale=640x480"', "libx264", "h264_nvenc", ".mp4"),
-                (5, "1920x1080", "webm", '-vf "fps=5,scale=1920x1080"', "libvpx-vp9", "libvpx-vp9", ".webm"),
-            ],
+def test_install_ffmpeg_success(mock_subprocess_run):
+    """Test install_ffmpeg when the command succeeds."""
+    mock_subprocess_run.return_value = MagicMock(returncode=0)
+    with patch("ai_graph.step.video.video_downsampling.ffdl") as mock_ffdl:
+        mock_ffdl.ffmpeg_path = "/path/to/ffmpeg"
+        mock_ffdl.ffprobe_path = "/path/to/ffprobe"
+        ffmpeg_path, ffprobe_path = install_ffmpeg()
+        assert ffmpeg_path == "/path/to/ffmpeg"
+        assert ffprobe_path == "/path/to/ffprobe"
+        mock_subprocess_run.assert_called_once_with(
+            ["ffdl", "install"], input=b"y\n", check=True
         )
-        def test_process_step_happy_path_generates_correct_ffmpeg_command_and_updates_data(
-            self,
-            output_fps,
-            output_resolution,
-            output_format,
-            expected_vf_param,
-            expected_codec_cpu,
-            expected_codec_gpu,
-            expected_suffix,
-            mock_cuda_availability,
-        ):
-            # Arrange
-            original_video_path = "/path/to/original_video.mp4"
-            original_fps = 30.0
-            self.mock_cap.get.side_effect = lambda prop: {cv2.CAP_PROP_FPS: original_fps}.get(prop, 0)
 
-            step = VideoDownsamplingStep(
-                output_fps=output_fps, output_resolution=output_resolution, output_format=output_format
-            )
-            data = {"video_path": original_video_path}
 
-            # Mock Path.with_name to control the output filename
-            mock_path_obj = MagicMock()
-            mock_path_obj.stem = "original_video"
-            mock_path_obj.suffix = ".mp4"
-            expected_output_stem = mock_path_obj.stem + "_downsampled"
-            expected_output_filename = expected_output_stem + expected_suffix
-            expected_output_path = f"/path/to/{expected_output_filename}"  # Use forward slashes
-            mock_path_obj.with_name.return_value = Path(expected_output_path)
+def test_install_ffmpeg_file_not_found(mock_subprocess_run):
+    """Test install_ffmpeg when ffdl command is not found."""
+    mock_subprocess_run.side_effect = FileNotFoundError
+    with pytest.raises(SystemExit):
+        install_ffmpeg()
 
-            with patch("pathlib.Path", return_value=mock_path_obj):
-                # Act
-                result = step._process_step(data)
 
-                # Assert
-                self.mock_subprocess_run.assert_called_once()
-                called_cmd = self.mock_subprocess_run.call_args[0][0]
+def test_install_ffmpeg_non_zero_exit(mock_subprocess_run):
+    """Test install_ffmpeg when command returns non-zero exit code."""
+    mock_subprocess_run.side_effect = subprocess.CalledProcessError(1, ["ffdl", "install"])
+    with pytest.raises(SystemExit):
+        install_ffmpeg()
 
-                # Check common parts of the command
-                assert f'ffmpeg -i "{original_video_path}"' in called_cmd
-                if expected_vf_param:  # Only include -vf if filters are present
-                    assert expected_vf_param in called_cmd
-                else:
-                    assert "-vf" not in called_cmd  # Ensure -vf is not present when no filters
 
-                # Check codec based on GPU availability
-                if mock_cuda_availability.return_value:
-                    assert f"-c:v {expected_codec_gpu}" in called_cmd
-                else:
-                    assert f"-c:v {expected_codec_cpu}" in called_cmd
+def test_video_downsampling_init():
+    """Test initialization of VideoDownsamplingStep."""
+    step = VideoDownsamplingStep(
+        output_fps=15, output_resolution="1280x720", output_format="webm", name="TestStep"
+    )
+    assert step.output_fps == 15
+    assert step.output_resolution == "1280x720"
+    assert step.output_format == "webm"
+    assert step.name == "TestStep"
 
-                assert "-c:a copy -max_muxing_queue_size 9999 -y" in called_cmd
-                assert f'"{expected_output_path}"' in called_cmd  # Use POSIX-style path
 
-                # Verify data dictionary updates
-                assert result["output_fps"] == output_fps
-                assert result["output_resolution"] == output_resolution
-                assert result["output_format"] == output_format
-                assert result["video_fps"] == original_fps
-                assert result["video_path"] == str(mock_path_obj.with_name.return_value)
+def test_get_video_fps_success(mock_subprocess_run, video_downsampling_step):
+    """Test _get_video_fps when FFprobe returns valid FPS data."""
+    # Reset mock to ignore calls from check_ffmpeg_availability
+    mock_subprocess_run.reset_mock()
+    mock_subprocess_run.return_value = MagicMock(
+        returncode=0,
+        stdout=json.dumps({"streams": [{"r_frame_rate": "30/1"}]}),
+        stderr="",
+    )
+    fps = video_downsampling_step._get_video_fps("/path/to/video.mp4")
+    assert fps == 30.0
+    mock_subprocess_run.assert_called_once_with(
+        f'"{video_downsampling_step.ffprobe_path}" -v error -select_streams v:0 -show_entries stream=r_frame_rate -of json "/path/to/video.mp4"',
+        shell=True,
+        capture_output=True,
+        text=True,
+    )
 
-        def test_process_step_raises_runtime_error_if_ffmpeg_fails(self):
-            self.mock_subprocess_run.return_value = MagicMock(returncode=1, stdout="", stderr="FFmpeg error message")
-            step = VideoDownsamplingStep(output_fps=15)
-            data = {"video_path": "/path/to/video.mp4"}
 
-            with pytest.raises(RuntimeError, match="FFmpeg failed with exit code 1"):
-                step._process_step(data)
+def test_get_video_fps_failure(mock_subprocess_run, video_downsampling_step):
+    """Test _get_video_fps when FFprobe fails."""
+    mock_subprocess_run.return_value = MagicMock(returncode=1, stderr="FFprobe error")
+    with pytest.raises(RuntimeError, match="FFprobe failed to retrieve FPS"):
+        video_downsampling_step._get_video_fps("/path/to/video.mp4")
 
-        def test_process_step_uses_gpu_acceleration_when_available(self, mock_cuda_availability):
-            mock_cuda_availability.return_value = True  # Simulate GPU available
-            step = VideoDownsamplingStep(output_fps=15)
-            data = {"video_path": "/path/to/video.mp4"}
 
-            # Mock Path.with_name to control the output filename
-            mock_path_obj = MagicMock()
-            mock_path_obj.stem = "video"
-            mock_path_obj.suffix = ".mp4"
-            mock_path_obj.with_name.return_value = Path("/path/to/video_15fps.mp4")
-            with patch("pathlib.Path", return_value=mock_path_obj):
-                step._process_step(data)
+def test_process_step_invalid_path(mock_path_isfile, video_downsampling_step):
+    """Test _process_step with an invalid video path."""
+    mock_path_isfile.return_value = False
+    data = {"video_path": "/invalid/path/video.mp4"}
+    with pytest.raises(FileNotFoundError, match="Invalid video path"):
+        video_downsampling_step._process_step(data)
 
-            called_cmd = self.mock_subprocess_run.call_args[0][0]
-            assert "-hwaccel cuda" in called_cmd
-            assert "-c:v h264_nvenc" in called_cmd  # Default GPU codec for mp4
 
-        def test_process_step_uses_cpu_when_gpu_not_available(self, mock_cuda_availability):
-            mock_cuda_availability.return_value = False  # Simulate GPU not available (default)
-            step = VideoDownsamplingStep(output_fps=15)
-            data = {"video_path": "/path/to/video.mp4"}
+def test_process_step_same_fps(mock_path_isfile, mock_subprocess_run, video_downsampling_step):
+    """Test _process_step when original and target FPS are the same."""
+    mock_path_isfile.return_value = True
+    mock_subprocess_run.return_value = MagicMock(
+        returncode=0,
+        stdout=json.dumps({"streams": [{"r_frame_rate": "10/1"}]}),
+        stderr="",
+    )
+    data = {"video_path": "/path/to/video.mp4"}
+    result = video_downsampling_step._process_step(data)
+    assert result["video_path"] == "/path/to/video.mp4"
+    assert result["output_fps"] == 10
+    assert result["video_fps"] == 10.0
+    assert result["output_resolution"] == "640x480"
+    assert result["output_format"] == "mp4"
 
-            # Mock Path.with_name to control the output filename
-            mock_path_obj = MagicMock()
-            mock_path_obj.stem = "video"
-            mock_path_obj.suffix = ".mp4"
-            mock_path_obj.with_name.return_value = Path("/path/to/video_15fps.mp4")
-            with patch("pathlib.Path", return_value=mock_path_obj):
-                step._process_step(data)
 
-            called_cmd = self.mock_subprocess_run.call_args[0][0]
-            assert "-hwaccel cuda" not in called_cmd  # Should not use GPU accel
-            assert "-c:v libx264" in called_cmd  # Default CPU codec for mp4
+from pathlib import Path
 
-        def test_process_step_handles_missing_video_path_in_data(self):
-            step = VideoDownsamplingStep()
-            data = {}  # Missing video_path
+def test_process_step_downsample(mock_path_isfile, mock_subprocess_run, video_downsampling_step):
+    """Test _process_step with actual downsampling."""
+    mock_path_isfile.return_value = True
+    mock_subprocess_run.side_effect = [
+        MagicMock(
+            returncode=0,
+            stdout=json.dumps({"streams": [{"r_frame_rate": "30/1"}]}),
+            stderr="",
+        ),  # FFprobe for FPS
+        MagicMock(returncode=0, stdout="success", stderr=""),  # FFmpeg for downsampling
+    ]
+    data = {"video_path": "/path/to/video.mp4"}
+    with patch.object(
+        video_downsampling_step, "_downsample_video"
+    ) as mock_downsample:
+        result = video_downsampling_step._process_step(data)
+        # Normalize the result path to use forward slashes for comparison
+        assert Path(result["video_path"]).as_posix() == "/path/to/video_downsampled.mp4"
+        assert result["output_fps"] == 10
+        assert result["video_fps"] == 30.0
+        assert result["output_resolution"] == "640x480"
+        assert result["output_format"] == "mp4"
+        mock_downsample.assert_called_once()
 
-            with pytest.raises(FileNotFoundError, match="Invalid video path"):
-                step._process_step(data)
+
+def test_downsample_video_cpu(mock_subprocess_run, video_downsampling_step):
+    """Test _downsample_video using CPU encoding."""
+    # Reset mock to ignore calls from check_ffmpeg_availability
+    mock_subprocess_run.reset_mock()
+    mock_subprocess_run.side_effect = [
+        MagicMock(returncode=0, stdout="auto", stderr=""),  # FFmpeg -hwaccels
+        MagicMock(returncode=0, stdout="success", stderr=""),  # FFmpeg downsample
+    ]
+    video_downsampling_step._downsample_video(
+        "/path/to/input.mp4", "/path/to/output.mp4", 10, "640x480", "mp4"
+    )
+    assert mock_subprocess_run.call_count == 2
+    cmd = mock_subprocess_run.call_args_list[1][0][0]
+    assert "libx264" in cmd
+    assert "fps=10" in cmd
+    assert "scale=640x480" in cmd
+
+
+def test_downsample_video_gpu(mock_subprocess_run, video_downsampling_step):
+    """Test _downsample_video using GPU encoding."""
+    mock_subprocess_run.reset_mock()
+    mock_subprocess_run.side_effect = [
+        MagicMock(returncode=0, stdout="cuda", stderr=""),  # FFmpeg -hwaccels
+        MagicMock(returncode=0, stdout="success", stderr=""),  # FFmpeg downsample
+    ]
+    video_downsampling_step._downsample_video(
+        "/path/to/input.mp4", "/path/to/output.mp4", 10, "640x480", "mp4"
+    )
+    assert mock_subprocess_run.call_count == 2
+    cmd = mock_subprocess_run.call_args_list[1][0][0]
+    assert "h264_nvenc" in cmd
+    assert "fps=10" in cmd
+    assert "scale=640x480" in cmd
+
+
+def test_downsample_video_webm(mock_subprocess_run, video_downsampling_step):
+    """Test _downsample_video with WebM format."""
+    mock_subprocess_run.reset_mock()
+    mock_subprocess_run.side_effect = [
+        MagicMock(returncode=0, stdout="cuda", stderr=""),  # FFmpeg -hwaccels
+        MagicMock(returncode=0, stdout="success", stderr=""),  # FFmpeg downsample
+    ]
+    video_downsampling_step._downsample_video(
+        "/path/to/input.mp4", "/path/to/output.webm", 10, "640x480", "webm"
+    )
+    assert mock_subprocess_run.call_count == 2
+    cmd = mock_subprocess_run.call_args_list[1][0][0]
+    assert "libvpx-vp9" in cmd
+    assert "fps=10" in cmd
+    assert "scale=640x480" in cmd
+
+
+def test_downsample_video_failure(mock_subprocess_run, video_downsampling_step):
+    """Test _downsample_video when FFmpeg fails."""
+    mock_subprocess_run.side_effect = [
+        MagicMock(returncode=0, stdout="auto", stderr=""),  # FFmpeg -hwaccels
+        subprocess.CalledProcessError(1, cmd="ffmpeg", stderr="FFmpeg error"),
+    ]
+    with pytest.raises(RuntimeError, match="FFmpeg failed"):
+        video_downsampling_step._downsample_video(
+            "/path/to/input.mp4", "/path/to/output.mp4", 10, "640x480", "mp4"
+        )

--- a/tests/step/test_video/test_video_downsampling.py
+++ b/tests/step/test_video/test_video_downsampling.py
@@ -30,9 +30,7 @@ def mock_path_isfile():
 @pytest.fixture
 def video_downsampling_step():
     """Fixture to create a VideoDownsamplingStep instance."""
-    return VideoDownsamplingStep(
-        output_fps=10, output_resolution="640x480", output_format="mp4"
-    )
+    return VideoDownsamplingStep(output_fps=10, output_resolution="640x480", output_format="mp4")
 
 
 def test_check_ffmpeg_availability_success(mock_subprocess_run):
@@ -69,9 +67,7 @@ def test_install_ffmpeg_success(mock_subprocess_run):
         ffmpeg_path, ffprobe_path = install_ffmpeg()
         assert ffmpeg_path == "/path/to/ffmpeg"
         assert ffprobe_path == "/path/to/ffprobe"
-        mock_subprocess_run.assert_called_once_with(
-            ["ffdl", "install"], input=b"y\n", check=True
-        )
+        mock_subprocess_run.assert_called_once_with(["ffdl", "install"], input=b"y\n", check=True)
 
 
 def test_install_ffmpeg_file_not_found(mock_subprocess_run):
@@ -90,9 +86,7 @@ def test_install_ffmpeg_non_zero_exit(mock_subprocess_run):
 
 def test_video_downsampling_init():
     """Test initialization of VideoDownsamplingStep."""
-    step = VideoDownsamplingStep(
-        output_fps=15, output_resolution="1280x720", output_format="webm", name="TestStep"
-    )
+    step = VideoDownsamplingStep(output_fps=15, output_resolution="1280x720", output_format="webm", name="TestStep")
     assert step.output_fps == 15
     assert step.output_resolution == "1280x720"
     assert step.output_format == "webm"
@@ -152,6 +146,7 @@ def test_process_step_same_fps(mock_path_isfile, mock_subprocess_run, video_down
 
 from pathlib import Path
 
+
 def test_process_step_downsample(mock_path_isfile, mock_subprocess_run, video_downsampling_step):
     """Test _process_step with actual downsampling."""
     mock_path_isfile.return_value = True
@@ -164,9 +159,7 @@ def test_process_step_downsample(mock_path_isfile, mock_subprocess_run, video_do
         MagicMock(returncode=0, stdout="success", stderr=""),  # FFmpeg for downsampling
     ]
     data = {"video_path": "/path/to/video.mp4"}
-    with patch.object(
-        video_downsampling_step, "_downsample_video"
-    ) as mock_downsample:
+    with patch.object(video_downsampling_step, "_downsample_video") as mock_downsample:
         result = video_downsampling_step._process_step(data)
         # Normalize the result path to use forward slashes for comparison
         assert Path(result["video_path"]).as_posix() == "/path/to/video_downsampled.mp4"
@@ -185,9 +178,7 @@ def test_downsample_video_cpu(mock_subprocess_run, video_downsampling_step):
         MagicMock(returncode=0, stdout="auto", stderr=""),  # FFmpeg -hwaccels
         MagicMock(returncode=0, stdout="success", stderr=""),  # FFmpeg downsample
     ]
-    video_downsampling_step._downsample_video(
-        "/path/to/input.mp4", "/path/to/output.mp4", 10, "640x480", "mp4"
-    )
+    video_downsampling_step._downsample_video("/path/to/input.mp4", "/path/to/output.mp4", 10, "640x480", "mp4")
     assert mock_subprocess_run.call_count == 2
     cmd = mock_subprocess_run.call_args_list[1][0][0]
     assert "libx264" in cmd
@@ -202,9 +193,7 @@ def test_downsample_video_gpu(mock_subprocess_run, video_downsampling_step):
         MagicMock(returncode=0, stdout="cuda", stderr=""),  # FFmpeg -hwaccels
         MagicMock(returncode=0, stdout="success", stderr=""),  # FFmpeg downsample
     ]
-    video_downsampling_step._downsample_video(
-        "/path/to/input.mp4", "/path/to/output.mp4", 10, "640x480", "mp4"
-    )
+    video_downsampling_step._downsample_video("/path/to/input.mp4", "/path/to/output.mp4", 10, "640x480", "mp4")
     assert mock_subprocess_run.call_count == 2
     cmd = mock_subprocess_run.call_args_list[1][0][0]
     assert "h264_nvenc" in cmd
@@ -219,9 +208,7 @@ def test_downsample_video_webm(mock_subprocess_run, video_downsampling_step):
         MagicMock(returncode=0, stdout="cuda", stderr=""),  # FFmpeg -hwaccels
         MagicMock(returncode=0, stdout="success", stderr=""),  # FFmpeg downsample
     ]
-    video_downsampling_step._downsample_video(
-        "/path/to/input.mp4", "/path/to/output.webm", 10, "640x480", "webm"
-    )
+    video_downsampling_step._downsample_video("/path/to/input.mp4", "/path/to/output.webm", 10, "640x480", "webm")
     assert mock_subprocess_run.call_count == 2
     cmd = mock_subprocess_run.call_args_list[1][0][0]
     assert "libvpx-vp9" in cmd
@@ -236,6 +223,4 @@ def test_downsample_video_failure(mock_subprocess_run, video_downsampling_step):
         subprocess.CalledProcessError(1, cmd="ffmpeg", stderr="FFmpeg error"),
     ]
     with pytest.raises(RuntimeError, match="FFmpeg failed"):
-        video_downsampling_step._downsample_video(
-            "/path/to/input.mp4", "/path/to/output.mp4", 10, "640x480", "mp4"
-        )
+        video_downsampling_step._downsample_video("/path/to/input.mp4", "/path/to/output.mp4", 10, "640x480", "mp4")

--- a/tests/step/test_video/test_video_downsampling.py
+++ b/tests/step/test_video/test_video_downsampling.py
@@ -1,5 +1,4 @@
 import json
-import os
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -104,12 +103,19 @@ def test_get_video_fps_success(mock_subprocess_run, video_downsampling_step):
     )
     fps = video_downsampling_step._get_video_fps("/path/to/video.mp4")
     assert fps == 30.0
-    mock_subprocess_run.assert_called_once_with(
-        f'"{video_downsampling_step.ffprobe_path}" -v error -select_streams v:0 -show_entries stream=r_frame_rate -of json "/path/to/video.mp4"',
-        shell=True,
-        capture_output=True,
-        text=True,
-    )
+
+
+mock_subprocess_run.assert_called_once_with(
+    (
+        f'"{video_downsampling_step.ffprobe_path}" '
+        "-v error -select_streams v:0 "
+        "-show_entries stream=r_frame_rate -of json "
+        '"/path/to/video.mp4"'
+    ),
+    shell=True,
+    capture_output=True,
+    text=True,
+)
 
 
 def test_get_video_fps_failure(mock_subprocess_run, video_downsampling_step):
@@ -142,9 +148,6 @@ def test_process_step_same_fps(mock_path_isfile, mock_subprocess_run, video_down
     assert result["video_fps"] == 10.0
     assert result["output_resolution"] == "640x480"
     assert result["output_format"] == "mp4"
-
-
-from pathlib import Path
 
 
 def test_process_step_downsample(mock_path_isfile, mock_subprocess_run, video_downsampling_step):


### PR DESCRIPTION
Implemented a new preprocessing step, VideoDownsamplingStep, that allows users to downsample videos using ffmpeg.

Added tests to validate functionality across different resolutions, frame rates, and formats.

Provided example usage in a Jupyter notebook to demonstrate integration with AI-Graph workflows.

Fixes #1 